### PR TITLE
Fix syllables order.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,9 @@ Syllables occur in the following order:
 - HS
 - SS
 - ALS0, ALS1, ALS2, ALS3, ALS4, ALS5
-- CS0, CS1
+- CS0
 - ALES2, ALES5
+- CS1
 - ALES0, ALES1, ALES3, ALES4
 - AAS0, AAS1, AAS2, AAS3, AAS4, AAS5
 - LTS3, LTS2, LTS1, LTS0


### PR DESCRIPTION
Слог ALES2+5 находится между CS0 и CS1.

```
{
    return %ctpr3
    setbn rsz = 0x3f, rbs = 0x3f, rcur = 0x3f
    fadds,2 %r0, %r0, %r0
}
```

hexdump
```
00000000 24 c0 40 10 << HS
00000004 80 80 80 30 << ALS2
00000008 00 00 00 f0 << CS0
0000000c 00 00 c0 02 << ALES2+5
00000010 ff ff 03 44 << CS1
00000014 00 00 00 00 << align
```